### PR TITLE
Implemented diffusion logic for objects that obstruct camera view (ob…

### DIFF
--- a/Assets/Scripts/MovementSystem/CameraController.cs
+++ b/Assets/Scripts/MovementSystem/CameraController.cs
@@ -1,28 +1,75 @@
 using UnityEngine;
+using System.Collections.Generic;
 
-namespace MovementSystem
+public class CameraController : MonoBehaviour
 {
-    public class CameraController : MonoBehaviour
+    public GameObject player;
+    // Layer mask of obstruction objects (That needs to be diffused)
+    public LayerMask obstructionLayer; 
+    // Material to apply when objects are obstructing the camera view
+    public Material transparentMaterial; 
+
+    private Vector3 offset;
+    
+    // Dictionary to store collided obj material before diffusion
+    // used to revert back from transparent to the org material
+    // when it does not obstruct camera view anymore
+    private Dictionary<Collider, Material> originalMaterials = new Dictionary<Collider, Material>(); 
+
+    void Start()
     {
-    
-        // This code is taken from "roll a ball" tutorials.
-        // I mean it fits here, because I want same camera following behaviour
-        // I will use perspective camera angled at 35 degrees. 
-    
-        public GameObject player;
+        offset = transform.position - player.transform.position;
 
-        private Vector3 offset;
-    
-        // Start is called before the first frame update
-        void Start()
+        // Add and configure the camera collider as a trigger
+        // // later used for the obstruction diffusion logic
+        BoxCollider cameraCollider = gameObject.AddComponent<BoxCollider>();
+        cameraCollider.isTrigger = true;
+        // Spawned collider size
+        cameraCollider.size = new Vector3(4f, 4f, 4f);
+        // Center the collider
+        cameraCollider.center = new Vector3(0f, 0f, 5f);  
+
+        // Add a Rigidbody to camera to interact with triggers,
+        // set to kinematic since we don't want physics forces applied
+        Rigidbody cameraRigidbody = gameObject.AddComponent<Rigidbody>();
+        cameraRigidbody.isKinematic = true;
+        cameraRigidbody.useGravity = false;
+    }
+
+    void LateUpdate()
+    {
+        // Move the camera to maintain the offset from the player
+        transform.position = player.transform.position + offset;
+    }
+
+    void OnTriggerEnter(Collider other)
+    {
+        // Check if the object is on the obstruction layer
+        if (((1 << other.gameObject.layer) & obstructionLayer) != 0)
         {
-            offset = transform.position - player.transform.position;
+            Renderer objRenderer = other.GetComponent<Renderer>();
+            if (objRenderer != null && !originalMaterials.ContainsKey(other))
+            {
+                // Save the original material and set to transparent
+                originalMaterials[other] = objRenderer.material;
+                objRenderer.material = transparentMaterial;
+            }
         }
+    }
 
-        // Update is called once per frame
-        void LateUpdate()
+    void OnTriggerExit(Collider other)
+    {
+        // Check if the object is in the dictionary of obstructions
+        if (originalMaterials.TryGetValue(other, out Material originalMaterial))
         {
-            transform.position = player.transform.position + offset;
+            Renderer objRenderer = other.GetComponent<Renderer>();
+            if (objRenderer != null)
+            {
+                // Restore the original material
+                objRenderer.material = originalMaterial;
+                // Remove from the dictionary
+                originalMaterials.Remove(other);
+            }
         }
     }
 }

--- a/Assets/Scripts/ObjectPool.cs
+++ b/Assets/Scripts/ObjectPool.cs
@@ -2,6 +2,8 @@
 using System.Linq;
 using UnityEngine;
 
+namespace ObjectPoolingSystem
+{
 public class ObjectPool : MonoBehaviour
 {
     public GameObject prefabToPool;
@@ -34,4 +36,5 @@ public class ObjectPool : MonoBehaviour
         return _pooledObjects.Count(obj => obj.activeInHierarchy);
     }
     
+}
 }

--- a/Assets/Scripts/ShootingSystem/Gun.cs
+++ b/Assets/Scripts/ShootingSystem/Gun.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using ObjectPoolingSystem;
 
 namespace ShootingSystem
 {

--- a/Assets/Scripts/ZombieSpawn.cs
+++ b/Assets/Scripts/ZombieSpawn.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using ObjectPoolingSystem;
 
 public class ZombieSpawnManager : MonoBehaviour
 {

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -13,7 +13,7 @@ TagManager:
   - 
   - Water
   - UI
-  - 
+  - CameraDiffuse
   - 
   - 
   - 


### PR DESCRIPTION
Implemented diffusion logic for objects that obstruct camera view. (objects that are getting between camera and character at some point) Specific objects assigned to a designated diffusion layer will become transparent when they obstruct the view between the camera and the player.

Enhanced camera control was essential for improved gameplay experience, as it prevents objects from interrupting the action.

+ In addition, since this is a top-down game, it now allows selective transparency of building sections. As a result, players will be able to see their character when navigating indoors.